### PR TITLE
Renamed `responseFull` to `response`...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
-# 0.5.0
+# Karet XHR Changelog
+
+## 0.6.0
+
+Renamed
+
+* `XHR.responseFull` to `XHR.response`
+
+and dropped the old `XHR.response` function, because getting the full response
+is what one normally wants to do and having `XHR.response` return partial
+results seems unnecessarily error prone.  The valid use cases of the old
+`XHR.response` can be implemented through `XHR.responseText`.
+
+## 0.5.0
 
 Changed `XHR.responseFull` to require that the download has completed
 successfully.
@@ -7,7 +20,7 @@ Changed `XHR.getJson` to wait that the XHR has completed successfully with a
 HTTP success status and to emit the XHR as an error in case the XHR fails or
 times out.
 
-# 0.4.0
+## 0.4.0
 
 Renamed
 
@@ -26,17 +39,17 @@ so that it sounds like a query.
 Changed `XHR.status`, `XHR.statusText`, `XHR.responseURL`, and `XHR.responseXML`
 to wait for / require a meaningful ready state.
 
-# 0.3.1
+## 0.3.1
 
 Fixed a bug introduced in 0.3.0 where observables were not properly eliminated
 from `perform` parameters in non-production mode.
 
-# 0.3.0
+## 0.3.0
 
 `performWith` now also merges default headers with override headers.
 `performJson` also includes header `Content-Type: application/json`.
 
-# 0.2.0
+## 0.2.0
 
 Previously `allResponseHeaders` and `responseHeader` produced `''` and `null`,
 respectively, before the HTTP headers were received.  Now they only emit their
@@ -45,7 +58,7 @@ results after the HTTP headers have been received.
 Previously `responseXML` produced `null` before the XHR was completed.  Now it
 only produces its result after the XHR has been completed like `responseFull`.
 
-# 0.1.3
+## 0.1.3
 
 Fixed a bug.  Previously the XHR was aborted unconditionally after unsubscribing
 from the returned property.  Aborting a completed XHR clears the XHR object,

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Examples:
       * [`XHR.responseHeader(header, xhr) ~> string`](#XHR-responseHeader)
     * [Response data](#response-data)
       * [`XHR.response(xhr) ~> varies`](#XHR-response)
-      * [`XHR.responseFull(xhr) ~> varies`](#XHR-responseFull)
       * [`XHR.responseText(xhr) ~> string`](#XHR-responseText)
       * [`XHR.responseXML(xhr) ~> document`](#XHR-responseXML)
     * [Response URL](#response-url)
@@ -91,6 +90,7 @@ Examples:
   * [Deprecated](#deprecated)
     * ~~[`XHR.downHasSucceeded(xhr) ~> boolean`](#XHR-downHasSucceeded)~~
     * ~~[`XHR.headersReceived(xhr) ~> boolean`](#XHR-headersReceived)~~
+    * ~~[`XHR.responseFull(xhr) ~> varies`](#XHR-responseFull)~~
     * ~~[`XHR.upHasSucceeded(xhr) ~> boolean`](#XHR-upHasSucceeded)~~
 
 ## <a id="reference"></a> [≡](#contents) [▶](https://calmm-js.github.io/karet.xhr/index.html#reference) [Reference](#reference)
@@ -114,8 +114,8 @@ and [upload](#upload-state) state.
 #### <a id="XHR-getJson"></a> [≡](#contents) [▶](https://calmm-js.github.io/karet.xhr/index.html#XHR-getJson) [`XHR.getJson(url | {url,[, ...]}) ~> varies`](#XHR-getJson)
 
 `XHR.getJson(arg)` returns an observable that emits the [full
-response](#XHR-responseFull) after the [XHR has succeeded](#XHR-hasSucceeded).
-In case the XHR fails or times out, the XHR is emitted as an error.
+response](#XHR-response) after the [XHR has succeeded](#XHR-hasSucceeded).  In
+case the XHR fails or times out, the XHR is emitted as an error.
 
 #### <a id="XHR-performJson"></a> [≡](#contents) [▶](https://calmm-js.github.io/karet.xhr/index.html#XHR-peformJson) [`XHR.performJson(url | {url[, ...]}) ~> xhr`](#XHR-performJson)
 
@@ -186,8 +186,7 @@ property.
 WARNING: Setting `responseType` to `'json'` is not supported by IE 11.  This
 library implements a workaround by calling `JSON.parse` on the returned data in
 case setting `responseType` to `'json'` fails.  In case the response does not
-parse, then [`XHR.response`](#XHR-response) and
-[`XHR.responseFull`](XHR-responseFull) return `null`.
+parse, then [`XHR.response`](#XHR-response) returns `null`.
 
 See this live [GitHub repository search](https://codesandbox.io/s/l5271q0r2l)
 CodeSandbox for an example.
@@ -208,12 +207,13 @@ obtained.  See also [`XHR.status`](#XHR-status),
 ##### <a id="XHR-isDone"></a> [≡](#contents) [▶](https://calmm-js.github.io/karet.xhr/index.html#XHR-isDone) [`XHR.isDone(xhr) ~> boolean`](#XHR-isDone)
 
 `XHR.isDone` returns a possibly observable boolean property that tells whether
-the XHR operation is complete (whether success or failure).
+the XHR operation is complete (whether success or failure).  See also
+[`XHR.hasSucceeded`](#XHR-hasSucceeded).
 
 ##### <a id="XHR-isProgressing"></a> [≡](#contents) [▶](https://calmm-js.github.io/karet.xhr/index.html#XHR-isProgressing) [`XHR.isProgressing(xhr) ~> boolean`](#XHR-isProgressing)
 
 `XHR.isProgressing` returns a possibly observable boolean property that tells
-whether the XHR operation has started, but has not yet [completed](#XHR-isDone).
+whether the XHR operation has started, but has not yet [ended](#XHR-isDone).
 
 #### <a id="end-state"></a> [≡](#contents) [▶](https://calmm-js.github.io/karet.xhr/index.html#end-state) [End state](#end-state)
 
@@ -296,30 +296,26 @@ an `Error` will be thrown.
 
 ##### <a id="XHR-response"></a> [≡](#contents) [▶](https://calmm-js.github.io/karet.xhr/index.html#XHR-response) [`XHR.response(xhr) ~> varies`](#XHR-response)
 
-`XHR.response` returns a possibly observable property of the
-[`response`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/response)
-of an ongoing XHR.  See also [`XHR.responseFull`](#XHR-responseFull).
-
-##### <a id="XHR-responseFull"></a> [≡](#contents) [▶](https://calmm-js.github.io/karet.xhr/index.html#XHR-responseFull) [`XHR.responseFull(xhr) ~> varies`](#XHR-responseFull)
-
-`XHR.responseFull` returns a possibly observable property that emits the
+`XHR.response` returns a possibly observable property that emits the
 [`response`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/response)
 after the [download operation of the XHR has completed](#XHR-downHasCompleted).
 When called on a non-observable XHR, the download operation must be completed or
-an `Error` will be thrown.  See also [`XHR.response`](#XHR-response).
+an `Error` will be thrown.  See also [`XHR.responseText`](#XHR-responseText).
 
 ##### <a id="XHR-responseText"></a> [≡](#contents) [▶](https://calmm-js.github.io/karet.xhr/index.html#XHR-responseText) [`XHR.responseText(xhr) ~> string`](#XHR-responseText)
 
 `XHR.responseText` returns a possibly observable property of the
 [`responseText`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseText)
-property of an ongoing XHR.
+property of an ongoing XHR.  `XHR.responseText` is for observing the received
+response data before the data has been completely received.  See also
+[`XHR.response`](#XHR-response).
 
 ##### <a id="XHR-responseXML"></a> [≡](#contents) [▶](https://calmm-js.github.io/karet.xhr/index.html#XHR-responseXML) [`XHR.responseXML(xhr) ~> document`](#XHR-responseXML)
 
 `XHR.responseXML` returns a possibly observable property of the
 [`responseXML`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseXML)
-property after the XHR has completed.  When called on a non-observable XHR, its
-[`readyState` must be 4](#XHR-isDone) or an `Error` will be thrown.  See also
+property after the XHR has completed.  When called on a non-observable XHR, the
+download operation must be completed or an `Error` will be thrown.  See also
 [`XHR.response`](#XHR-response).
 
 #### <a id="response-url"></a> [≡](#contents) [▶](https://calmm-js.github.io/karet.xhr/index.html#response-url) [Response URL](#response-url)
@@ -496,6 +492,10 @@ See also [`XHR.statusIsHttpSuccess`](#XHR-statusIsHttpSuccess).
 
 `XHR.headersReceived` has been renamed to
 [`XHR.isStatusAvailable`](#XHR-isStatusAvailable).
+
+#### <a id="XHR-responseFull"></a> [≡](#contents) [▶](https://calmm-js.github.io/karet.xhr/index.html#XHR-responseFull) ~~[`XHR.responseFull(xhr) ~> varies`](#XHR-responseFull)~~
+
+`XHR.responseFull` has been renamed to [`XHR.response`](#XHR-response).
 
 #### <a id="XHR-upHasSucceeded"></a> [≡](#contents) [▶](https://calmm-js.github.io/karet.xhr/index.html#XHR-upHasSucceeded) ~~[`XHR.upHasSucceeded(xhr) ~> boolean`](#XHR-upHasSucceeded)~~
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "karet.xhr",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karet.xhr",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "An observable wrapper for XMLHttpRequest using Kefir",
   "module": "dist/karet.xhr.es.js",
   "main": "dist/karet.xhr.cjs.js",

--- a/src/karet.xhr.js
+++ b/src/karet.xhr.js
@@ -294,19 +294,19 @@ export const errors = setName(
   'errors'
 )
 export const response = setName(
-  I.pipe2U(
-    F.lift(({xhr, parse}) => {
-      const response = xhr[RESPONSE]
-      return parse ? tryParse(response) : response
-    }),
-    skipAcyclicEquals
+  getAfter(
+    downHasCompleted,
+    I.pipe2U(
+      F.lift(({xhr, parse}) => {
+        const response = xhr[RESPONSE]
+        return parse ? tryParse(response) : response
+      }),
+      skipAcyclicEquals
+    )
   ),
   RESPONSE
 )
-export const responseFull = setName(
-  getAfter(downHasCompleted, response),
-  'responseFull'
-)
+
 export const responseType = setName(L.get([XHR, RESPONSE_TYPE]), RESPONSE_TYPE)
 export const responseURL = setName(
   getAfter(isStatusAvailable, L.get([XHR, RESPONSE_URL])),
@@ -404,7 +404,7 @@ export const getJson = setName(
     performJson,
     flatMapLatestToProperty(xhr => {
       if (hasSucceeded(xhr)) {
-        return K.constant(responseFull(xhr))
+        return K.constant(response(xhr))
       } else if (isDone(xhr) && (hasFailed(xhr) || hasTimedOut(xhr))) {
         return K.constantError(xhr)
       } else {
@@ -433,4 +433,5 @@ const renamed =
 
 export const downHasSucceeded = renamed(downHasCompleted, 'downHasSucceeded')
 export const headersReceived = renamed(isStatusAvailable, 'headersReceived')
+export const responseFull = renamed(response, 'responseFull')
 export const upHasSucceeded = renamed(upHasCompleted, 'upHasSucceeded')

--- a/test/tests.js
+++ b/test/tests.js
@@ -102,7 +102,7 @@ describe('XHR', () => {
     XHR.statusIsHttpSuccess(XHR.perform({url: 'http://localhost:3000/text'}))
   )
   testEq(['Hello, mocha!'], () =>
-    XHR.responseFull(
+    XHR.response(
       XHR.perform({
         url: K.constant('http://localhost:3000/text'),
         timeout: 10000,
@@ -153,7 +153,7 @@ describe('XHR', () => {
     )
   )
   testEq([{user: '101'}], () =>
-    XHR.responseFull(
+    XHR.response(
       XHR.perform({
         url: 'http://localhost:3000/json',
         responseType: 'json',
@@ -173,14 +173,12 @@ describe('XHR', () => {
     ).map(xml => xml.firstChild.textContent)
   )
   testEq(['Still there?'], () =>
-    XHR.responseFull(
+    XHR.response(
       XHR.perform({url: 'http://localhost:3000/slow', timeout: 2000})
     )
   )
   testEq([], () =>
-    XHR.responseFull(
-      XHR.perform({url: 'http://localhost:3000/slow', timeout: 200})
-    )
+    XHR.response(XHR.perform({url: 'http://localhost:3000/slow', timeout: 200}))
   )
   testEq([false, true], () =>
     XHR.hasTimedOut(
@@ -198,7 +196,7 @@ describe('XHR', () => {
     ).takeUntilBy(K.later(200, 'anything'))
   )
   testEq([{returnTo: 'sender'}], () =>
-    XHR.responseFull(
+    XHR.response(
       XHR.perform({
         url: 'http://localhost:3000/echo',
         method: 'POST',
@@ -212,7 +210,7 @@ describe('XHR', () => {
     XHR.perform({url: 'http://localhost:3000/slow', timeout: 2000})
       .map(xhr => {
         try {
-          return XHR.responseFull(xhr)
+          return XHR.response(xhr)
         } catch (e) {
           return e.message === 'downHasCompleted'
         }


### PR DESCRIPTION
...and dropped the old `response` completely.